### PR TITLE
Add check for SERPER_API_KEY

### DIFF
--- a/serper_scraper.py
+++ b/serper_scraper.py
@@ -3,9 +3,13 @@ import csv
 from datetime import datetime
 import re
 import os
+import sys
 
 # API key for Serper (set SERPER_API_KEY environment variable)
 API_KEY = os.getenv("SERPER_API_KEY")
+if not API_KEY:
+    print("SERPER_API_KEY environment variable not set. Please set it before running the script.")
+    sys.exit(1)
 QUERY = "thai dishes recipes"
 
 headers = {"X-API-KEY": API_KEY, "Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
- stop running the scraper if SERPER_API_KEY isn't set

## Testing
- `python -m py_compile serper_scraper.py`
- `pip install -r requirements.txt`
- `python serper_scraper.py` *(fails: SERPER_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68412a6402988331948593d3d82aedf7